### PR TITLE
test mode changed to client mode.

### DIFF
--- a/src/test/java/org/superbiz/ColorServiceTest.java
+++ b/src/test/java/org/superbiz/ColorServiceTest.java
@@ -56,7 +56,7 @@ public class ColorServiceTest extends Assert {
      *
      * More than one @Deployment method is allowed.
      */
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addClasses(ColorService.class, Color.class);
     }


### PR DESCRIPTION
Because of the nature of Arquillian Test, it should be started as client mode and not in-container. In-Container executes the test inside the container, in this case the test is connecting to a remote endpoint so acting as a client.